### PR TITLE
Don't strip url params - PMT #103693

### DIFF
--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -2662,7 +2662,7 @@ SherdBookmarklet = {
             var assetUrl = asset.sources[asset.primary_type];
             if(assetUrl !== undefined){
                 // make sure to strip out any url params
-                asset.sources[asset.primary_type] = assetUrl.split('?')[0];
+                asset.sources[asset.primary_type] = assetUrl;
             }
             if (!asset) return;
             var doc = comp.ul.ownerDocument;

--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -2661,7 +2661,6 @@ SherdBookmarklet = {
         this.displayAsset = function(asset,index) {
             var assetUrl = asset.sources[asset.primary_type];
             if(assetUrl !== undefined){
-                // make sure to strip out any url params
                 asset.sources[asset.primary_type] = assetUrl;
             }
             if (!asset) return;


### PR DESCRIPTION
On digitalcollections.nypl.org, the image src's are
PHP scripts that require url params in order to display
correctly.
