### PR TITLE
Fix video collection bug - PMT #98114

### DIFF
--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -1454,7 +1454,7 @@ SherdBookmarklet = {
                     result.push(rv);
                 }
                 for (i = 0; i < result.length; i++) {
-                    MediathreadCollect.metadataSearch(
+                    SherdBookmarklet.metadataSearch(
                         result[i], context.document);
                 }
                 callback(result);


### PR DESCRIPTION
This fixes an 'undefined' error in the bookmarklet. I can now collect videos on the 9/11 archive.
